### PR TITLE
Housekeeping updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,17 +24,17 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>1.13</version>
+      <version>1.19.3</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey.contribs</groupId>
       <artifactId>jersey-apache-client</artifactId>
-      <version>1.13</version>
+      <version>1.19.3</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-json</artifactId>
-      <version>1.13</version>
+      <version>1.19.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/com/amphibian/weather/response/Forecast.java
+++ b/src/main/java/com/amphibian/weather/response/Forecast.java
@@ -34,6 +34,14 @@ public class Forecast {
 	}
 	
 	/**
+	 * The forecast days to be set
+	 * @param days
+	 */
+	public void setDays(List<ForecastDay> days) {
+		this.days = days;
+	}
+
+	/**
 	 * This is used when the response is XML format. For whatever reason,
 	 * wunderground.com gives the XML forecastday tags wrapped with a forecastdays
 	 * object but the JSON version is just an array of forecastday objects.


### PR DESCRIPTION
There seems to be a bug in Jersey 1.13 (and 1.14) that is fixed in later versions.  The bug is captured here: https://java.net/jira/browse/JERSEY-1459.  This caused an error when receiving a forecast from weather underground.

I also added a setter for forecastDays to facilitate unit testing.